### PR TITLE
Add wdm package if launched on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'github-pages'
 gem 'compass'
 gem 'sass-media_query_combiner'
 gem 'autoprefixer-rails'
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
See https://github.com/Maher4Ever/wdm

This will avoid polling for changes when running jekyll locally on Windows.
