### PR TITLE
Add all regional DevFests to the list, only run through them once

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ rightNavigationButtons:
 heroImage: "hero.jpg"
 heroTitle: "DevFest <typeout>"
 eventDate: "13/14/15 November 2015"
-typeoutTextValues: '"", "Karlsruhe", "Hamburg", "Vienna", "Berlin 2015", ""'
+typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "Brussels?", "Berlin 2015 !!!"'
 typeoutFallback: "Berlin 2015"
 heroButtons:
  - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}

--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ rightNavigationButtons:
 heroImage: "hero.jpg"
 heroTitle: "DevFest <typeout>"
 eventDate: "13/14/15 November 2015"
-typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "Brussels?", "Berlin 2015 !!!"'
+typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "Brussels?", "Berlin 2015!"'
 typeoutFallback: "Berlin 2015"
 heroButtons:
  - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,9 +79,10 @@ layout: compress
                     if ($(window).width() > 767) {
                         $("#typeout-text").typed({
                             strings: [{{site.typeoutTextValues}}],
+                            startDelay: 500,
                             typeSpeed: 150,
                             backDelay: 900,
-                            loop: true
+                            loop: false
                         });
                     }
                 });


### PR DESCRIPTION
The hero animation now runs through all DevFests of the region but stops when it reaches Berlin.

It also runs through them as "Karlsruhe?", "Hamburg?" and finishes with "Berlin 2015!!!".

I hope this will lead to a more clear message of where the user landed. :wink: 
