### PR TITLE
Enable ticket sales on homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -135,8 +135,8 @@ subscribeAction: "https://gdg.us5.list-manage1.com/subscribe/post?u=9fc8aa205b05
 subscribeInfo: "Registration will be open around end of August. Number of tickets are limited. Stay tuned!"
 
 # Tickets Block
-ticketsTitle: "Pricetable"
-ticketsInfo: "Tickets grant access to all conference sections, coffee breakes, lunch and party. Accommodation is NOT included in the ticket price."
+ticketsTitle: "Get your ticket NOW!"
+ticketsInfo: "Tickets grant access to all conference sections on all 3 days, incl. coffee breakes, lunch and party. Accommodation is NOT included in the ticket price."
 ticketsOffers:
  -
   name: "Early Bird"

--- a/_config.yml
+++ b/_config.yml
@@ -53,8 +53,10 @@ navigationLinks:
  - {permalink: "https://plus.google.com/+DevFestBerlin/", text: "Google+ Page"}
 bottomNavigationLinks:
  - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
+ - {link: "/#tickets", text: "Buy a ticket"}
 rightNavigationButtons:
  - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
+ - {link: "/#tickets", text: "Buy a ticket"}
 
 # Hero Block
 heroImage: "hero.jpg"
@@ -64,7 +66,7 @@ typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "B
 typeoutFallback: "Berlin 2015"
 heroButtons:
  - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
-# - {permalink: "/#tickets", text: "Buy tickets"}
+ - {permalink: "/#tickets", text: "Buy tickets"}
 
 # About Block
 aboutTitle: "About DevFest Berlin"

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -3,32 +3,8 @@
 	<div class="content-wrapper">
 		<div class="col-lg-8 col-md-10 col-lg-offset-2 col-md-offset-1">
 			<h3>{{ site.ticketsTitle }}</h3>
-            {% for ticketsOffer in site.ticketsOffers %}
-	            {% assign colWidth = 12 | divided_by: forloop.length %}
-	            {% assign check = forloop.index | modulo:2 %}
-	            <div class="col-md-{{ colWidth }} col-sm-{{ colWidth }} pricing-col {% if ticketsOffer.featured != null %}pricing-col-featured{% endif %} animated hiding" data-animation="{% if forloop.index == 1 %}fadeInLeft{% elsif forloop.index == forloop.length %}fadeInRight{% else %}fadeInDown{% endif %}" data-delay="{% if check == 0 %}0{% else %}500{% endif %}">
-	            	{% if ticketsOffer.ribbon != null %}<div class="pricing-ribbon">{{ ticketsOffer.ribbon }}</div>{% endif %}
-					<div class="pricing-header">
-						<p class="title">{{ ticketsOffer.name }}</p>
-						<p class="price">{{ ticketsOffer.price }} <span class="currency">{{ ticketsOffer.priceCurrency }}</span></p>
-					</div>
-					<div class="pricing-content">
-						<ul>
-							{% for listItem in ticketsOffer.ticketContentList %}
-							<li>{{ listItem }}</li>
-							{% endfor %}
-						</ul>
-						{% if ticketsOffer.soldOut == true %}
-						<span class="button disabled">{{ ticketsOffer.soldOutText }}</span>
-						{% elsif ticketsOffer.disabled != true %}
-						<a class="button" href="{{ ticketsOffer.buyButtonLink }}" target="_blank">{{ ticketsOffer.buyButtonText }}</a>
-						{% else %}
-		           		{% assign ticketValidFrom = ticketsOffer.validFrom | split: "T" %}
-						<span class="button disabled fallback">Ticket sales will begin on {{ ticketValidFrom[0] | date: "%-d %B %Y"}} {{ ticketValidFrom[1] }}</span>
-						{% endif %}
-					</div>
-				</div>
-            {% endfor %}
+			<p>{{ site.ticketsInfo }}</p>
+            <script type="text/javascript" src="https://www.amiando.com/resources/js/amiandoExport.js"></script><iframe src="https://www.amiando.com/DevFestBerlin2015.html?viewType=iframe&distributionChannel=CHANNEL_IFRAME&panelId=2690962&useDefaults=false&resizeIFrame=true" frameborder="0" width="650px" height="650px" id="_amiandoIFrame2690962"><p>Diese Seite benötigt die Unterstützung von Frames durch Ihren Browser. Bitte nutzen Sie einen Browser, der die Darstellung von Frames unterstützt, damit das amiando Ticketvorverkauf Widget angezeigt werden kann.</p><p>Probieren Sie die amiando <a href="http://de.amiando.com/features.html">online Registrierung</a> noch heute aus.</p></iframe><p style="text-align: left; font-size:10px;"><a href="http://de.amiando.com?viralRefId=DevFestBerlin2015&utm_campaign=ev-DevFestBerlin2015&utm_medium=viral&utm_source=EventWebsite&utm_content=TextLinkBottom&utm_term=text-link" target="_blank" alt="Konferenz - Online Event Management" title="Konferenz - Online Event Management" >Konferenz - Online Event Management</a> mit der Ticketing-Lösung von XING EVENTS</p>
 		</div>
 	</div>
 </section>

--- a/index.html
+++ b/index.html
@@ -25,8 +25,10 @@ permalink: /
  {% include partners.html %}
 
  {% include subscribe.html %}
+{% endcomment %}
 
  {% include tickets.html %}
 
+{% comment %}
  {% include tickets-2.html %}
 {% endcomment %}


### PR DESCRIPTION
This PR enables the ticket section on the front page as an include for the ticket shop at https://www.amiando.com/DevFestBerlin2015.html
### Cover

![image](https://cloud.githubusercontent.com/assets/45467/10419225/6e7ea158-7071-11e5-8f88-7c9476a07252.png)
### Navigation button added

![image](https://cloud.githubusercontent.com/assets/45467/10419230/93ed4d90-7071-11e5-9812-3486218a989a.png)
### Ticket section

![image](https://cloud.githubusercontent.com/assets/45467/10419234/a9d05ab2-7071-11e5-937f-0764d0a4f7a9.png)

Ticket management is possible through XING Events and will displayed on our website immediately. Coupon codes for reduced prizes or hidden categories (speakers, organizers) can be applied from here.

I generate coupon codes and different categories to encourage sales. History/Details can be found in [the trello board](https://trello.com/c/7ON8IPud)
