### PR TITLE
Add Maps API talk as a placeholder

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -52,7 +52,7 @@
     - {
         startTime: "12:00",
         endTime: "12:45",
-        sessionIds: [332, 300, 326]
+        sessionIds: [332, 337, 326]
     }
     - {
         startTime: "12:45",

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -287,6 +287,16 @@
   complexity: "Intermediate" # Beginner / Intermediate / Expert
   #video: ""
   #presentation: ""
+-
+  id: 337
+  title: "Google Maps API, Google"
+  description: "&lt;insert talk details here /&gt;"
+  subtype: presentation
+  speakers: []
+  language: en
+  complexity: "Beginner" # Beginner / Intermediate / Expert
+  #video: ""
+  #presentation: ""
 
 # 4xx hackathon day
 -


### PR DESCRIPTION
In order to remove the last placeholder and complete the schedule I recommend adding the general topic and updating it with description, title and speaker asap.
