### PR TITLE
List all (available) speakers for the fireside chats

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -98,7 +98,10 @@
 -
   id: 305
   title: "Fireside chat with all speakers of the Cloud track"
-  description: ""
+  description: "Ask the speakers anything about their talks or related developments in their field."
+  speakers: [004,005,007,008,011,019]
+  subtype: discussion
+  language: en
 -
   id: 306
   title: "Wrap-Up"

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -84,7 +84,10 @@
 -
   id: 303
   title: "Fireside chat with all speakers of the Android track"
-  description: ""
+  description: "Ask the speakers anything about their talks or related developments in their field."
+  speakers: [012,013,014,017,018]
+  subtype: discussion
+  language: en
 -
   id: 304
   title: "Fireside chat with all speakers of the Web track"

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -91,7 +91,10 @@
 -
   id: 304
   title: "Fireside chat with all speakers of the Web track"
-  description: ""
+  description: "Ask the speakers anything about their talks or related developments in their field."
+  speakers: [009,010,020,021,022]
+  subtype: discussion
+  language: en
 -
   id: 305
   title: "Fireside chat with all speakers of the Cloud track"

--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -161,7 +161,7 @@
   name: "Igor"
   surname: "Filippov"
   title: "Software Developer"
-  company: ""
+  company: "&nbsp;"
   bio: "Software developer with experience in building mobile apps for millions of users. Interested in wide range in technologies: Node.js, Go, Machine Learning, Artificial Intelligence. Spent more than 5 years developing Android and iOS apps. Focused on architecture, test automation, agile. Built award winning apps: kaufda, retale, bonial, meinprospekt, wifarer, mspy and others."
   thumbnailUrl: "IgorFilippov.jpg"
   rockstar: true


### PR DESCRIPTION
This PR adds the speakers and a little description to the fireside chat entries on the schedule.

It'll look like this:

![image](https://cloud.githubusercontent.com/assets/45467/10924117/fb3862f8-8284-11e5-99d4-ff869797defb.png)
