### PR TITLE
Schedule android workshop / Add Google Maps workshop info

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -18,8 +18,13 @@
     }
     - {
     	startTime: "15:00",
-    	endTime: "18:30",
+    	endTime: "",
     	sessionIds: [203, 204, 205]
+    }
+    - {
+        startTime: "&nbsp;",
+        endTime: "18:30",
+        sessionIds: [206, 404, 404]
     }
 - 
   date: "2015-11-14"

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -37,10 +37,11 @@
   complexity: "Beginner"
 -
   id: 204
-  title: "Web workshop TBA"
-  description: "The workshop topic and requirements will be announced soon™."
-  place: ""
+  title: "Google Maps API Workshop"
+  description: "The Google Maps Team is stopping by along their #CodeTheRoad tour and will introduce you to the the Google Maps API in a hands-on session."
+  subtype: workshop
   language: en
+  complexity: "Beginner"
 -
   id: 205
   title: "Hands-on with Kubernetes"


### PR DESCRIPTION
Found a way to tweak the schedule to display 2 Android workshops for the same time slot. 

![image](https://cloud.githubusercontent.com/assets/45467/10995877/72e8991a-8480-11e5-84ba-1d94ed58950d.png)

I think this is good enough. Comments?
