### PR TITLE
Remove Call for Participation + minor corrections

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,7 @@ eventDate: "13/14/15 November 2015"
 typeoutTextValues: '"Karlsruhe?", "Hamburg?", "Vienna?", "Malta?", "Zurich?", "Brussels?", "Berlin 2015!"'
 typeoutFallback: "Berlin 2015"
 heroButtons:
- - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
+ - {permalink: "/schedule", text: "See the schedule"} 
  - {permalink: "/#tickets", text: "Buy tickets"}
 
 # About Block

--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ navigationLinks:
  - {permalink: "/team/", text: "Team"}
  - {permalink: "/code-of-conduct/", text: "Code of Conduct"}
 # - {permalink: "/hackathon/", text: "Hackathon"}
- - {permalink: "https://plus.google.com/+DevFestBerlin/", text: "Google+ Page"}
+ - {permalink: "https://plus.google.com/+DevFestBerlin", text: "Google+ Page"}
 bottomNavigationLinks:
  - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
  - {link: "/#tickets", text: "Buy a ticket"}

--- a/_config.yml
+++ b/_config.yml
@@ -52,10 +52,8 @@ navigationLinks:
 # - {permalink: "/hackathon/", text: "Hackathon"}
  - {permalink: "https://plus.google.com/+DevFestBerlin", text: "Google+ Page"}
 bottomNavigationLinks:
- - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
  - {link: "/#tickets", text: "Buy a ticket"}
 rightNavigationButtons:
- - {link: "https://conference.devfest-berlin.de/en/devfestberlin2015/cfp/session/new", text: "Become a speaker"}
  - {link: "/#tickets", text: "Buy a ticket"}
 
 # Hero Block

--- a/_config.yml
+++ b/_config.yml
@@ -78,7 +78,7 @@ statisticBlockImage: "statistic.jpg"
 statisticBlock:
  - {count: "250", specialCharacter: "+", info: "attendees", detail: "from everywhere"}
  - {count: "36", specialCharacter: "+", info: "hours", detail: "of pure Google technologies"}
- - {count: "24", specialCharacter: "+", info: "speakers", detail: "from the local community and beyond"}
+ - {count: "18", specialCharacter: "+", info: "speakers", detail: "from the local community and beyond"}
  - {count: "3", specialCharacter: "", info: "parallel tracks", detail: "plus entertainment lounge"}
 
 # Latest News Block


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/45467/11011886/281d93d2-84ed-11e5-8321-1c9adb98dd17.png)
- remove CfP buttons from header and footer
- replace the center CfP button with the schedule link (see screenshot)
- correct the number of speakers 
- correct the DevFest G+ url
