### PR TITLE
Remove remaining CfP button

### DIFF
--- a/_includes/speakers-list.html
+++ b/_includes/speakers-list.html
@@ -50,7 +50,9 @@
                 </div>
                 {% endfor %}
             </div> 
-            <a href="{{ site.c4pUrl }}" class="btn btn-primary waves-effect waves-button waves-light waves-float" target="_blank">Become a speaker</a>     
+            {% comment %}
+            <a href="{{ site.c4pUrl }}" class="btn btn-primary waves-effect waves-button waves-light waves-float" target="_blank">Become a speaker</a>
+            {% endcomment %}
         </div>
     </div>
 </section>


### PR DESCRIPTION
This removes the last left over call for papers-button at the end of the speaker site.
