### PR TITLE
Add id to speaker in speaker list (for scroll mark)

### DIFF
--- a/_includes/speakers-list.html
+++ b/_includes/speakers-list.html
@@ -4,7 +4,7 @@
         <div class="col-lg-10 col-lg-offset-1">
             <div class="row text-left appear-animation-trigger">
                 {% for speaker in site.data.speakers %}
-                <div class="effect-wrapper appear-animation col-md-4 col-sm-6 col-xs-12">
+                <div id="speakerDetail-{{ speaker.id }}" class="effect-wrapper appear-animation col-md-4 col-sm-6 col-xs-12">
                     <div class="lily-effect ribbon-activator">
                         <div class="lily-head" data-toggle="modal" data-target="#speakerDetail-{{ speaker.id }}">
                             <figure class="waves-effect waves-block waves-light" style="background-image: url({{ site.baseurl | append: '/img/people/' | append: speaker.thumbnailUrl }})">


### PR DESCRIPTION
This scroll mark is needed to allow speaker links, e.g. the code the road blog post, to scroll down to the speakers entry.
