### PR TITLE
Fix the 6th slot timing to consider the break

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -75,13 +75,13 @@
         sessionIds: [329, 335, 323]
     }
     - {
-        startTime: "15:45",
-        endTime: "16:30",
+        startTime: "16:00",
+        endTime: "16:45",
         sessionIds: [328, 336, 322]
     }
     - {
-        startTime: "16:30",
-        endTime: "17:15",
+        startTime: "16:45",
+        endTime: "17:30",
         sessionIds: [102]
     }
     - {


### PR DESCRIPTION
That slipped until now that the break was not accounted for between slot 5 and 6.
